### PR TITLE
Helppatch: put camera instructions in Handling

### DIFF
--- a/badMapper (DX9) help.v4p
+++ b/badMapper (DX9) help.v4p
@@ -1,5 +1,5 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha32.2.dtd" >
-   <PATCH nodename="C:\Users\Domi\Documents\GitHub\badMapper\badMapper (DX9) help.v4p" systemname="badMapper3 (DX9) help" filename="C:\Users\Domi\Documents\GitHub\badMapper-v3.0\badMapper3 (DX9) help.v4p" scrollx="17190" scrolly="-96">
+   <PATCH nodename="C:\Users\Domi\Documents\GitHub\badMapper\badMapper (DX9) help.v4p" systemname="badMapper3 (DX9) help" filename="C:\Users\Domi\Documents\GitHub\badMapper-v3.0\badMapper3 (DX9) help.v4p" scrollx="0" scrolly="0">
    <BOUNDS type="Window" left="4665" top="6900" width="17850" height="8355">
    </BOUNDS>
    <PACK Name="addonpack" Version="32.2.0">


### PR DESCRIPTION
the hint '-mousewheel to zoom, right drag to pan' was in the Source Window section, it is now in the Handling section.

This is because zooming was only available in the Source Window, but now it's also available in Destination Preview Window.
