### PR TITLE
Fixing red nodes

### DIFF
--- a/sub/Cursor (DX9 OwnLegacy FixedEnum).v4p
+++ b/sub/Cursor (DX9 OwnLegacy FixedEnum).v4p
@@ -1,0 +1,1065 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.7.dtd" >
+   <PATCH nodename="D:\GIT\badMapper\sub\Cursor (DX9 OwnLegacy FixedEnum).v4p" systemname="Cursor (DX9 Legacy FixedEnum)" filename="D:\GIT\badMapper\sub\Cursor (DX9 Legacy FixedEnum).v4p">
+   <BOUNDS height="13830" left="5310" top="840" type="Window" width="19065">
+   </BOUNDS>
+   <NODE id="35" nodename="Quad (DX9)" systemname="Quad (DX9)">
+   <BOUNDS height="0" left="6465" top="9705" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Transform" visible="1">
+   </PIN>
+   <PIN pinname="Color" visible="1">
+   </PIN>
+   <PIN pinname="Texture" slicecount="1" visible="1" values="||">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Enabled" visible="1" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE id="32" nodename="Translate (Transform Vector)" systemname="Translate (Transform Vector)">
+   <BOUNDS height="0" left="6750" top="4350" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="X" visible="1">
+   </PIN>
+   <PIN pinname="Y" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1">
+   </PIN>
+   <PIN pinname="XYZ" visible="1" slicecount="3" values="0,0,0">
+   </PIN>
+   </NODE>
+   <NODE id="30" nodename="Scale (Transform)" systemname="Scale (Transform)">
+   <BOUNDS height="0" left="6630" top="9180" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="XYZ">
+   </PIN>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="X" slicecount="1" visible="1" values="20">
+   </PIN>
+   <PIN pinname="Y" slicecount="1" visible="1" values="2">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="29" nodename="IOBox (Color)" systemname="IOBox (Color)">
+   <BOUNDS height="0" left="7815" top="8895" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="160" left="10485" top="10920" type="Window" width="215">
+   </BOUNDS>
+   <BOUNDS height="270" left="7815" top="8895" type="Box" width="660">
+   </BOUNDS>
+   <PIN pinname="Color Input" slicecount="1" values="|1.00000,1.00000,1.00000,1.00000|">
+   </PIN>
+   <PIN pinname="Show Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Color Output" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" encoded="0" values="Color">
+   </PIN>
+   </NODE>
+   <NODE id="26" nodename="SetAlpha (Color)" systemname="SetAlpha (Color)">
+   <BOUNDS height="0" left="7770" top="9300" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Alpha" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="26" dstpinname="Input" srcnodeid="29" srcpinname="Color Output">
+   </LINK>
+   <LINK dstnodeid="35" dstpinname="Color" srcnodeid="26" srcpinname="Output">
+   </LINK>
+   <NODE id="25" nodename="Map (Value)" systemname="Map (Value)">
+   <BOUNDS height="0" left="8730" top="8805" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Destination Minimum" slicecount="1" values="0.5">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="24" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
+   <BOUNDS height="0" left="12435" top="1485" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="160" left="11460" top="11625" type="Window" width="215">
+   </BOUNDS>
+   <BOUNDS height="465" left="12435" top="1485" type="Box" width="630">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" encoded="0" values="Selection">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN pinname="Y Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Slider Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Show Slider" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Show Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <NODE id="22" nodename="Quad (DX9)" systemname="Quad (DX9)">
+   <BOUNDS height="0" left="930" top="9675" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Transform" visible="1">
+   </PIN>
+   <PIN pinname="Enabled" visible="1">
+   </PIN>
+   <PIN pinname="Color" slicecount="1" values="|1.00000,1.00000,1.00000,0.50459|">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Render State" visible="1">
+   </PIN>
+   </NODE>
+   <NODE id="21" nodename="Transform (Transform 2d)" systemname="Transform (Transform 2d)">
+   <BOUNDS height="0" left="1095" top="8670" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Transform In" visible="1">
+   </PIN>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="TranslateX" visible="1">
+   </PIN>
+   <PIN pinname="TranslateY" visible="1">
+   </PIN>
+   <PIN pinname="ScaleX" visible="1">
+   </PIN>
+   <PIN pinname="Rotate" visible="1">
+   </PIN>
+   <PIN pinname="ScaleY" visible="1" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <NODE id="20" nodename="TogEdge (Animation)" systemname="TogEdge (Animation)">
+   <BOUNDS height="0" left="1080" top="3375" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Up Edge" visible="1">
+   </PIN>
+   <PIN pinname="Bang On Create" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE id="19" nodename="S+H (Animation)" systemname="S+H (Animation)">
+   <BOUNDS height="0" left="690" top="3915" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1" slicecount="3" values="0,0,0">
+   </PIN>
+   <PIN pinname="Set" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="19" dstpinname="Set" srcnodeid="20" srcpinname="Up Edge">
+   </LINK>
+   <NODE id="18" nodename="AND (Boolean)" systemname="AND (Boolean)">
+   <BOUNDS height="0" left="12525" top="2265" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="18" dstpinname="Input 2" srcnodeid="24" srcpinname="Y Output Value">
+   </LINK>
+   <NODE id="17" nodename="Vector (3d Split)" systemname="Vector (3d Split)">
+   <BOUNDS height="0" left="690" top="4320" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="XYZ" visible="1">
+   </PIN>
+   <PIN pinname="X" visible="1">
+   </PIN>
+   <PIN pinname="Y" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="17" dstpinname="XYZ" srcnodeid="19" srcpinname="Output">
+   </LINK>
+   <NODE id="16" nodename="Vector (3d Split)" systemname="Vector (3d Split)">
+   <BOUNDS height="0" left="1485" top="4320" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="XYZ" visible="1" slicecount="3" values="0,0,0">
+   </PIN>
+   <PIN pinname="X" visible="1">
+   </PIN>
+   <PIN pinname="Y" visible="1">
+   </PIN>
+   </NODE>
+   <NODE id="15" nodename="Points2Vector (2d)" systemname="Points2Vector (2d)">
+   <BOUNDS height="0" left="1140" top="5610" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="X" visible="1">
+   </PIN>
+   <PIN pinname="Y" visible="1">
+   </PIN>
+   <PIN pinname="Length" visible="1">
+   </PIN>
+   <PIN pinname="X1" visible="1">
+   </PIN>
+   <PIN pinname="Y1" visible="1">
+   </PIN>
+   <PIN pinname="Angle" visible="1">
+   </PIN>
+   <PIN pinname="X2" visible="1">
+   </PIN>
+   <PIN pinname="Y2" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="21" dstpinname="TranslateX" srcnodeid="15" srcpinname="X">
+   </LINK>
+   <LINK dstnodeid="21" dstpinname="TranslateY" srcnodeid="15" srcpinname="Y">
+   </LINK>
+   <LINK dstnodeid="21" dstpinname="Rotate" srcnodeid="15" srcpinname="Angle">
+   </LINK>
+   <NODE id="14" nodename="Stallone (Spreads)" systemname="Stallone (Spreads)">
+   <BOUNDS height="0" left="705" top="5160" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input Sort" pintype="Input" slicecount="1" visible="-1" values="Slice">
+   </PIN>
+   <PIN pinname="Input Count" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Output Sort" pintype="Input" slicecount="1" visible="-1" values="Slice">
+   </PIN>
+   <PIN pinname="Spread Count" pintype="Input" slicecount="1" visible="0" values="4">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 3" visible="1">
+   </PIN>
+   <PIN pinname="Input 4" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="14" dstpinname="Input 1" srcnodeid="17" srcpinname="X">
+   </LINK>
+   <LINK dstnodeid="15" dstpinname="X1" srcnodeid="14" srcpinname="Output 1">
+   </LINK>
+   <NODE id="13" nodename="Stallone (Spreads)" systemname="Stallone (Spreads)">
+   <BOUNDS height="0" left="1500" top="5160" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input Sort" pintype="Input" slicecount="1" visible="-1" values="Slice">
+   </PIN>
+   <PIN pinname="Input Count" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Output Sort" pintype="Input" slicecount="1" visible="-1" values="Slice">
+   </PIN>
+   <PIN pinname="Spread Count" pintype="Input" slicecount="1" visible="0" values="4">
+   </PIN>
+   <PIN pinname="Input 1" slicecount="1" visible="1" values="0.00000">
+   </PIN>
+   <PIN pinname="Output 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 3" visible="1">
+   </PIN>
+   <PIN pinname="Input 4" visible="1">
+   </PIN>
+   </NODE>
+   <NODE id="12" nodename="Stallone (Spreads)" systemname="Stallone (Spreads)">
+   <BOUNDS height="0" left="2295" top="5160" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input Sort" pintype="Input" slicecount="1" visible="-1" values="Slice">
+   </PIN>
+   <PIN pinname="Input Count" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Output Sort" pintype="Input" slicecount="1" visible="-1" values="Slice">
+   </PIN>
+   <PIN pinname="Spread Count" pintype="Input" slicecount="1" visible="0" values="4">
+   </PIN>
+   <PIN pinname="Input 1" slicecount="1" visible="1" values="0.00000">
+   </PIN>
+   <PIN pinname="Output 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 3" visible="1">
+   </PIN>
+   <PIN pinname="Input 4" visible="1">
+   </PIN>
+   </NODE>
+   <NODE id="11" nodename="Stallone (Spreads)" systemname="Stallone (Spreads)">
+   <BOUNDS height="0" left="3090" top="5160" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Input Sort" pintype="Input" slicecount="1" visible="-1" values="Slice">
+   </PIN>
+   <PIN pinname="Input Count" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Output Sort" pintype="Input" slicecount="1" visible="-1" values="Slice">
+   </PIN>
+   <PIN pinname="Spread Count" pintype="Input" slicecount="1" visible="0" values="4">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 3" visible="1">
+   </PIN>
+   <PIN pinname="Input 4" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="15" dstpinname="X2" srcnodeid="12" srcpinname="Output 1">
+   </LINK>
+   <LINK dstnodeid="13" dstpinname="Input 1" srcnodeid="17" srcpinname="Y">
+   </LINK>
+   <LINK dstnodeid="12" dstpinname="Input 1" srcnodeid="16" srcpinname="X">
+   </LINK>
+   <LINK dstnodeid="11" dstpinname="Input 1" srcnodeid="17" srcpinname="Y">
+   </LINK>
+   <LINK dstnodeid="14" dstpinname="Input 2" srcnodeid="16" srcpinname="X">
+   </LINK>
+   <LINK dstnodeid="13" dstpinname="Input 2" srcnodeid="17" srcpinname="Y">
+   </LINK>
+   <LINK dstnodeid="12" dstpinname="Input 2" srcnodeid="16" srcpinname="X">
+   </LINK>
+   <LINK dstnodeid="11" dstpinname="Input 2" srcnodeid="16" srcpinname="Y">
+   </LINK>
+   <LINK dstnodeid="14" dstpinname="Input 3" srcnodeid="16" srcpinname="X">
+   </LINK>
+   <LINK dstnodeid="13" dstpinname="Input 3" srcnodeid="16" srcpinname="Y">
+   </LINK>
+   <LINK dstnodeid="12" dstpinname="Input 3" srcnodeid="17" srcpinname="X">
+   </LINK>
+   <LINK dstnodeid="11" dstpinname="Input 3" srcnodeid="16" srcpinname="Y">
+   </LINK>
+   <LINK dstnodeid="14" dstpinname="Input 4" srcnodeid="17" srcpinname="X">
+   </LINK>
+   <LINK dstnodeid="13" dstpinname="Input 4" srcnodeid="16" srcpinname="Y">
+   </LINK>
+   <LINK dstnodeid="12" dstpinname="Input 4" srcnodeid="17" srcpinname="X">
+   </LINK>
+   <LINK dstnodeid="11" dstpinname="Input 4" srcnodeid="17" srcpinname="Y">
+   </LINK>
+   <LINK dstnodeid="15" dstpinname="Y1" srcnodeid="13" srcpinname="Output 1">
+   </LINK>
+   <LINK dstnodeid="15" dstpinname="Y2" srcnodeid="11" srcpinname="Output 1">
+   </LINK>
+   <NODE componentmode="InABox" id="4" nodename="IOBox (String)" systemname="IOBox (String)">
+   <BOUNDS height="270" left="6735" top="10050" type="Node" width="585">
+   </BOUNDS>
+   <BOUNDS height="270" left="6735" top="10050" type="Box" width="585">
+   </BOUNDS>
+   <BOUNDS height="160" left="0" top="0" type="Window" width="215">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" encoded="0" values="cross">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="3" nodename="IOBox (String)" systemname="IOBox (String)">
+   <BOUNDS height="270" left="825" top="10095" type="Node" width="1530">
+   </BOUNDS>
+   <BOUNDS height="270" left="825" top="10095" type="Box" width="1530">
+   </BOUNDS>
+   <BOUNDS height="160" left="0" top="0" type="Window" width="215">
+   </BOUNDS>
+   <PIN pinname="Input String" slicecount="1" visible="0" encoded="0" values="|selection rectangle|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <NODE componentmode="InABox" id="2" nodename="IOBox (Node)" systemname="IOBox (Node)">
+   <BOUNDS height="0" left="1950" top="11460" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="160" left="7920" top="10815" type="Window" width="215">
+   </BOUNDS>
+   <BOUNDS height="240" left="1950" top="11460" type="Box" width="795">
+   </BOUNDS>
+   <PIN pinname="Input Node" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" encoded="0" values="Layer">
+   </PIN>
+   </NODE>
+   <NODE id="1" nodename="Group (EX9)" systemname="Group (EX9)">
+   <BOUNDS height="0" left="1950" top="11010" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Layer 1" visible="1">
+   </PIN>
+   <PIN pinname="Layer 2" visible="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Enabled" visible="1">
+   </PIN>
+   </NODE>
+   <LINK dstnodeid="2" dstpinname="Input Node" srcnodeid="1" srcpinname="Layer">
+   </LINK>
+   <LINK dstnodeid="1" dstpinname="Layer 1" srcnodeid="22" srcpinname="Layer">
+   </LINK>
+   <LINK dstnodeid="1" dstpinname="Layer 2" srcnodeid="35" srcpinname="Layer">
+   </LINK>
+   <NODE componentmode="InABox" hiddenwhenlocked="0" id="0" nodename="IOBox (Value Advanced)" systemname="IOBox (Value Advanced)">
+   <BOUNDS height="0" left="14130" top="10020" type="Node" width="0">
+   </BOUNDS>
+   <BOUNDS height="160" left="1995" top="1785" type="Window" width="215">
+   </BOUNDS>
+   <BOUNDS height="450" left="14130" top="10020" type="Box" width="615">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" encoded="0" values="Enabled">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN pinname="Slider Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Show Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Show Slider" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <INFO author="vvvv group" description="draws a cross-shaped cursor into the ex9 renderer. it also can draw a selection rectangle." tags="GUI, ex9, editor, modelling">
+   </INFO>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="37" systemname="IOBox (Node)">
+   <BOUNDS type="Node" left="3855" top="360" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3855" top="360" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Node" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" encoded="0" values="Mouse">
+   </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="0" srcpinname="Y Output Value" dstnodeid="1" dstpinname="Enabled">
+   </LINK>
+   <LINK srcnodeid="18" srcpinname="Output" dstnodeid="22" dstpinname="Enabled">
+   </LINK>
+   <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="42">
+   <BOUNDS type="Node" left="8610" top="855" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8610" top="855" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN pinname="Y Input Value" slicecount="1" values="1.5">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" encoded="0" values="Size">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="-1000">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="1000">
+   </PIN>
+   </NODE>
+   <NODE id="5" nodename="UniformScale (Transform)" systemname="UniformScale (Transform)">
+   <BOUNDS height="0" left="6720" top="5790" type="Node" width="0">
+   </BOUNDS>
+   <PIN pinname="Transform In" visible="1">
+   </PIN>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="XYZ" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="42" srcpinname="Y Output Value" dstnodeid="5" dstpinname="XYZ">
+   </LINK>
+   <NODE id="40" systemname="WithinProjection (Transform)" nodename="WithinProjection (Transform)" componentmode="Hidden" hiddenwhenlocked="0" managers="">
+   <BOUNDS type="Node" left="3990" top="3345" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1" pintype="Output">
+   </PIN>
+   <PIN pinname="Descriptive Name" pintype="Configuration" slicecount="1" encoded="0" values="||">
+   </PIN>
+   <PIN pinname="nix" pintype="Input" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Transform In" pintype="Input" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="ID" pintype="Output" visible="-1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="40" srcpinname="Transform Out" dstnodeid="32" dstpinname="Transform In" hiddenwhenlocked="1">
+   </LINK>
+   <NODE systemname="Billboard (Transform)" nodename="Billboard (Transform)" componentmode="Hidden" id="44">
+   <BOUNDS type="Node" left="6720" top="5295" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform In" visible="1">
+   </PIN>
+   <PIN pinname="Object Space" slicecount="1" values="Pixel">
+   </PIN>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="44" srcpinname="Transform Out" dstnodeid="5" dstpinname="Transform In">
+   </LINK>
+   <LINK srcnodeid="21" srcpinname="Transform Out" dstnodeid="22" dstpinname="Transform">
+   </LINK>
+   <NODE systemname="Fill (EX9.RenderState)" nodename="Fill (EX9.RenderState)" componentmode="Hidden" id="48">
+   <BOUNDS type="Node" left="510" top="9225" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Render State Out" visible="1">
+   </PIN>
+   <PIN pinname="Fill Mode" slicecount="1" values="WireFrame">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="48" srcpinname="Render State Out" dstnodeid="22" dstpinname="Render State">
+   </LINK>
+   <LINK srcnodeid="40" srcpinname="Transform Out" dstnodeid="21" dstpinname="Transform In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="15" srcpinname="Length" dstnodeid="21" dstpinname="ScaleX">
+   </LINK>
+   <NODE systemname="OR (Boolean Spectral)" nodename="OR (Boolean Spectral)" componentmode="Hidden" id="54">
+   <BOUNDS type="Node" left="4725" top="2190" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Bin Size" slicecount="1" values="3">
+   </PIN>
+   </NODE>
+   <NODE systemname="Vector (3d Join)" nodename="Vector (3d Join)" componentmode="Hidden" id="55">
+   <BOUNDS type="Node" left="4725" top="1770" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="X" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Y" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Z" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="XYZ" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="55" srcpinname="XYZ" dstnodeid="54" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="54" srcpinname="Output" dstnodeid="20" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="54" srcpinname="Output" dstnodeid="18" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="54" srcpinname="Output" dstnodeid="25" dstpinname="Input" hiddenwhenlocked="1">
+   </LINK>
+   <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="56">
+   <BOUNDS type="Node" left="6735" top="4815" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="6735" top="4815" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Node" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   <PIN pinname="Bin Size" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="30" srcpinname="Transform Out" dstnodeid="35" dstpinname="Transform">
+   </LINK>
+   <LINK srcnodeid="32" srcpinname="Transform Out" dstnodeid="56" dstpinname="Input Node">
+   </LINK>
+   <LINK srcnodeid="56" srcpinname="Output Node" dstnodeid="44" dstpinname="Transform In">
+   </LINK>
+   <NODE systemname="Select (Value)" nodename="Select (Value)" componentmode="Hidden" id="57" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll">
+   <BOUNDS type="Node" left="8730" top="9285" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Select" slicecount="1" values="2">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="25" srcpinname="Output" dstnodeid="57" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="57" srcpinname="Output" dstnodeid="26" dstpinname="Alpha">
+   </LINK>
+   <NODE systemname="MouseStates (Mouse Split)" filename="%VVVV%\lib\nodes\plugins\VVVV.Nodes.dll" nodename="MouseStates (Mouse Split)" componentmode="Hidden" id="36">
+   <BOUNDS type="Node" left="3870" top="1020" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input">
+   </PIN>
+   <PIN pinname="Left Button" visible="1">
+   </PIN>
+   <PIN pinname="X" visible="1">
+   </PIN>
+   <PIN pinname="Y" visible="1">
+   </PIN>
+   <PIN pinname="Middle Button" visible="1">
+   </PIN>
+   <PIN pinname="Right Button" visible="1">
+   </PIN>
+   <PIN pinname="Mouse" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="PositionXY" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="36" srcpinname="Left Button" dstnodeid="55" dstpinname="X">
+   </LINK>
+   <LINK srcnodeid="36" srcpinname="Middle Button" dstnodeid="55" dstpinname="Y">
+   </LINK>
+   <LINK srcnodeid="36" srcpinname="Right Button" dstnodeid="55" dstpinname="Z">
+   </LINK>
+   <LINK srcnodeid="37" srcpinname="Output Node" dstnodeid="36" dstpinname="Mouse">
+   </LINK>
+   <NODE systemname="xyZ (3d XY)" nodename="xyZ (3d XY)" componentmode="Hidden" id="38">
+   <BOUNDS type="Node" left="3870" top="1755" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="X" visible="1">
+   </PIN>
+   <PIN pinname="Y" visible="1">
+   </PIN>
+   <PIN pinname="XYZ" visible="1">
+   </PIN>
+   <PIN pinname="XY" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="38" srcpinname="XYZ" dstnodeid="32" dstpinname="XYZ">
+   </LINK>
+   <LINK srcnodeid="38" srcpinname="XYZ" dstnodeid="19" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="38" srcpinname="XYZ" dstnodeid="16" dstpinname="XYZ">
+   </LINK>
+   <LINK srcnodeid="36" srcpinname="PositionXY" dstnodeid="38" dstpinname="XY">
+   </LINK>
+   <PACK Name="addonpack" Version="35.0.0">
+   </PACK>
+   <NODE systemname="Switch (Node Input)" nodename="Switch (Node Input)" componentmode="Hidden" id="79">
+   <BOUNDS type="Node" left="6285" top="7260" width="9975" height="270">
+   </BOUNDS>
+   <PIN pinname="Input Count" slicecount="1" values="7">
+   </PIN>
+   <PIN pinname="Switch" visible="1" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 3" visible="1">
+   </PIN>
+   <PIN pinname="Input 4" visible="1">
+   </PIN>
+   <PIN pinname="Input 5" visible="1">
+   </PIN>
+   <PIN pinname="Input 6" visible="1">
+   </PIN>
+   <PIN pinname="Input 7" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Rotate (Transform Vector)" nodename="Rotate (Transform Vector)" componentmode="Hidden" id="78">
+   <BOUNDS type="Node" left="7710" top="6750" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="XYZ" slicecount="6" values="0,0,0.125,0,0,-0.125">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="78" srcpinname="Transform Out" dstnodeid="79" dstpinname="Input 1">
+   </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="77" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="8940" top="7725" width="690" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8940" top="7725" width="690" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="Vertical">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="76" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="10305" top="7725" width="900" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="10305" top="7725" width="900" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="Horizontal">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="75" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="11955" top="7725" width="300" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="11955" top="7725" width="300" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="LB">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="74" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="13305" top="7725" width="570" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="13305" top="7725" width="555" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="RB">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="73" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="14730" top="7725" width="570" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="14730" top="7725" width="570" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="LT">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="72" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="16155" top="7725" width="615" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="16155" top="7725" width="615" height="270">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="RT">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE systemname="Rotate (Transform Vector)" nodename="Rotate (Transform Vector)" componentmode="Hidden" id="71">
+   <BOUNDS type="Node" left="9135" top="6750" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="XYZ" slicecount="3" values="0,0,0.25">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="71" srcpinname="Transform Out" dstnodeid="79" dstpinname="Input 2">
+   </LINK>
+   <NODE systemname="Rotate (Transform Vector)" nodename="Rotate (Transform Vector)" componentmode="Hidden" id="70">
+   <BOUNDS type="Node" left="10500" top="6750" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="XYZ" slicecount="3" values="0,0,0">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="70" srcpinname="Transform Out" dstnodeid="79" dstpinname="Input 3">
+   </LINK>
+   <NODE systemname="Transform (Transform 2d)" nodename="Transform (Transform 2d)" componentmode="Hidden" id="69">
+   <BOUNDS type="Node" left="11940" top="6750" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="ScaleY" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="TranslateY" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="CenterX">
+   </PIN>
+   <PIN pinname="CenterY" slicecount="1" values="0.04">
+   </PIN>
+   <PIN pinname="Rotate">
+   </PIN>
+   <PIN pinname="TranslateX" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="ScaleX" visible="1" slicecount="1" values="0.7">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="69" srcpinname="Transform Out" dstnodeid="79" dstpinname="Input 4">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="68" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="12930" top="6360" width="510" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="12930" top="6360" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="-8.6">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Real">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="68" srcpinname="Y Output Value" dstnodeid="69" dstpinname="CenterX">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="67" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="12765" top="5775" width="510" height="450">
+   </BOUNDS>
+   <BOUNDS type="Node" left="12765" top="5775" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="2" values="0.25,0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="|0, 0|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="67" srcpinname="Y Output Value" dstnodeid="69" dstpinname="Rotate">
+   </LINK>
+   <NODE systemname="Transform (Transform 2d)" nodename="Transform (Transform 2d)" componentmode="Hidden" id="66">
+   <BOUNDS type="Node" left="13365" top="6750" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Rotate" visible="1">
+   </PIN>
+   <PIN pinname="CenterX" visible="1">
+   </PIN>
+   <PIN pinname="ScaleX" visible="1" slicecount="1" values="0.7">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="66" srcpinname="Transform Out" dstnodeid="79" dstpinname="Input 5">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="65" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="14340" top="6360" width="450" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="14340" top="6360" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="-8.6">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Real">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="64" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="14205" top="5775" width="510" height="450">
+   </BOUNDS>
+   <BOUNDS type="Node" left="14205" top="5775" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="2" values="0.5,0.25">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="|0, 0|">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="64" srcpinname="Y Output Value" dstnodeid="66" dstpinname="Rotate">
+   </LINK>
+   <LINK srcnodeid="65" srcpinname="Y Output Value" dstnodeid="66" dstpinname="CenterX">
+   </LINK>
+   <NODE systemname="Transform (Transform 2d)" nodename="Transform (Transform 2d)" componentmode="Hidden" id="63">
+   <BOUNDS type="Node" left="14775" top="6750" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="CenterX" visible="1">
+   </PIN>
+   <PIN pinname="Rotate" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="ScaleX" slicecount="1" values="0.7">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="63" srcpinname="Transform Out" dstnodeid="79" dstpinname="Input 6">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="62" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="15735" top="6360" width="480" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="15735" top="6360" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="-8.6">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Real">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="61" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="15585" top="5775" width="510" height="450">
+   </BOUNDS>
+   <BOUNDS type="Node" left="15585" top="5775" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="2" values="0,-0.25">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="|0, 0|">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="62" srcpinname="Y Output Value" dstnodeid="63" dstpinname="CenterX">
+   </LINK>
+   <LINK srcnodeid="61" srcpinname="Y Output Value" dstnodeid="63" dstpinname="Rotate">
+   </LINK>
+   <NODE systemname="Transform (Transform 2d)" nodename="Transform (Transform 2d)" componentmode="Hidden" id="60">
+   <BOUNDS type="Node" left="16185" top="6750" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   <PIN pinname="CenterX" visible="1">
+   </PIN>
+   <PIN pinname="Rotate" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="ScaleX" slicecount="1" values="0.7">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="59" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="17160" top="6360" width="510" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="17160" top="6360" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" values="-8.6">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Real">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="58" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="17010" top="5775" width="510" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="17010" top="5775" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="2" values="-0.25,0.5">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="2">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="|0, 0|">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="59" srcpinname="Y Output Value" dstnodeid="60" dstpinname="CenterX">
+   </LINK>
+   <LINK srcnodeid="58" srcpinname="Y Output Value" dstnodeid="60" dstpinname="Rotate">
+   </LINK>
+   <LINK srcnodeid="60" srcpinname="Transform Out" dstnodeid="79" dstpinname="Input 7">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="78" dstpinname="Transform In" hiddenwhenlocked="0">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="71" dstpinname="Transform In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="70" dstpinname="Transform In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="69" dstpinname="Transform In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="66" dstpinname="Transform In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="63" dstpinname="Transform In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Transform Out" dstnodeid="60" dstpinname="Transform In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="79" srcpinname="Output" dstnodeid="30" dstpinname="Transform In">
+   </LINK>
+   <NODE systemname="Enum2Ord (Enumerations)" nodename="Enum2Ord (Enumerations)" componentmode="Hidden" id="82">
+   <BOUNDS type="Node" left="6240" top="1290" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Enum" visible="1">
+   </PIN>
+   <PIN pinname="Ord Value" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="NULL (Enumerations)" nodename="NULL (Enumerations)" componentmode="Hidden" id="83">
+   <BOUNDS type="Node" left="5685" top="1290" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Enum" slicecount="1" values="CursorType">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="85" systemname="IOBox (Enumerations)">
+   <BOUNDS type="Box" left="6240" top="720" width="1590" height="270">
+   </BOUNDS>
+   <BOUNDS type="Node" left="6240" top="720" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" values="Cross">
+   </PIN>
+   <PIN pinname="Output Enum" visible="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Cursor Type|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="85" srcpinname="Output Enum" dstnodeid="83" dstpinname="Receive">
+   </LINK>
+   <LINK srcnodeid="85" srcpinname="Output Enum" dstnodeid="82" dstpinname="Enum">
+   </LINK>
+   <LINK srcnodeid="82" srcpinname="Ord Value" dstnodeid="79" dstpinname="Switch">
+   </LINK>
+   <PACK Name="VVVV.Packs" Version="0.1.0">
+   </PACK>
+   </PATCH>

--- a/sub/Destination (DX9).v4p
+++ b/sub/Destination (DX9).v4p
@@ -1,8 +1,8 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta34.2.dtd" >
-   <PATCH nodename="C:\Users\joreg\Documents\repos\badMapper\sub\Destination (DX9).v4p" systemname="destination" filename="C:\Users\Domi\Documents\GitHub\badMapper-v3.0\sub\destination.v4p" scrollx="0" scrolly="4965">
-   <BOUNDS type="Window" left="3390" top="5535" width="28980" height="13980">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.7.dtd" >
+   <PATCH nodename="D:\GIT\badMapper\sub\Destination (DX9).v4p" systemname="destination" filename="C:\Users\Domi\Documents\GitHub\badMapper-v3.0\sub\destination.v4p" scrollx="0" scrolly="0">
+   <BOUNDS type="Window" left="-120" top="-120" width="29040" height="15840">
    </BOUNDS>
-   <PACK Name="addonpack" Version="34.1.0">
+   <PACK Name="addonpack" Version="35.0.0">
    </PACK>
    <NODE systemname="Group (EX9)" nodename="Group (EX9)" componentmode="Hidden" id="21">
    <BOUNDS type="Node" left="5460" top="6510" width="10410" height="270">
@@ -414,36 +414,6 @@
    <PIN pinname="Output Node" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="Cursor (DX9)" filename="%VVVV%\lib\nodes\modules\EX9\Cursor (DX9).v4p" nodename="Cursor (DX9)" componentmode="Hidden" id="213">
-   <BOUNDS type="Node" left="1635" top="12480" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Layer" visible="1">
-   </PIN>
-   <PIN pinname="Mouse" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Cursor Type" visible="1">
-   </PIN>
-   <BOUNDS type="Window" left="-18570" top="10635" width="19065" height="13830">
-   </BOUNDS>
-   <PIN pinname="Enabled" visible="1">
-   </PIN>
-   <PIN pinname="Selection" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="213" srcpinname="Layer" dstnodeid="36" dstpinname="Layer 4">
-   </LINK>
-   <LINK srcnodeid="212" srcpinname="Output Node" dstnodeid="213" dstpinname="Mouse" linkstyle="VHV">
-   <LINKPOINT x="15925" y="12130">
-   </LINKPOINT>
-   <LINKPOINT x="2585" y="12080">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="158" srcpinname="Output Enum" dstnodeid="213" dstpinname="Cursor Type" linkstyle="VHV">
-   <LINKPOINT x="13860" y="12115">
-   </LINKPOINT>
-   <LINKPOINT x="1830" y="12155">
-   </LINKPOINT>
-   </LINK>
    <NODE systemname="IOBox (Value Advanced)" nodename="IOBox (Value Advanced)" componentmode="InABox" id="214">
    <BOUNDS type="Node" left="17925" top="525" width="100" height="100">
    </BOUNDS>
@@ -680,12 +650,6 @@
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="252" srcpinname="Y Output Value" dstnodeid="213" dstpinname="Selection" linkstyle="VHV">
-   <LINKPOINT x="15480" y="12315">
-   </LINKPOINT>
-   <LINKPOINT x="2340" y="12330">
-   </LINKPOINT>
-   </LINK>
    <NODE systemname="Polygon (PolygonEditor Split)" filename="%VVVV%\addonpack\lib\nodes\modules\2d\PolygonEditor\Polygon (PolygonEditor Split).v4p" nodename="Polygon (PolygonEditor Split)" componentmode="Hidden" id="204">
    <BOUNDS type="Node" left="8205" top="1830" width="100" height="100">
    </BOUNDS>
@@ -930,48 +894,6 @@
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <NODE systemname="Cursor (DX9)" filename="%VVVV%\lib\nodes\modules\EX9\Cursor (DX9).v4p" nodename="Cursor (DX9)" componentmode="Hidden" id="268">
-   <BOUNDS type="Node" left="6945" top="10350" width="100" height="100">
-   </BOUNDS>
-   <PIN pinname="Layer" visible="1">
-   </PIN>
-   <PIN pinname="Mouse" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Cursor Type" visible="1">
-   </PIN>
-   <BOUNDS type="Window" left="-18570" top="10635" width="19065" height="13830">
-   </BOUNDS>
-   <PIN pinname="Enabled" visible="1">
-   </PIN>
-   <PIN pinname="Selection" visible="1">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="212" srcpinname="Output Node" dstnodeid="268" dstpinname="Mouse" linkstyle="VHV">
-   <LINKPOINT x="15925" y="9760">
-   </LINKPOINT>
-   <LINKPOINT x="7895" y="9710">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="158" srcpinname="Output Enum" dstnodeid="268" dstpinname="Cursor Type" linkstyle="VHV">
-   <LINKPOINT x="14300" y="9890">
-   </LINKPOINT>
-   <LINKPOINT x="6700" y="9835">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="144" srcpinname="Y Output Value" dstnodeid="268" dstpinname="Enabled" linkstyle="VHV">
-   <LINKPOINT x="19530" y="10170">
-   </LINKPOINT>
-   <LINKPOINT x="7665" y="10185">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="252" srcpinname="Y Output Value" dstnodeid="268" dstpinname="Selection" linkstyle="VHV">
-   <LINKPOINT x="15920" y="10225">
-   </LINKPOINT>
-   <LINKPOINT x="7210" y="10145">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="268" srcpinname="Layer" dstnodeid="238" dstpinname="Layer 3">
-   </LINK>
    <NODE systemname="OR (Boolean)" nodename="OR (Boolean)" componentmode="Hidden" id="269">
    <BOUNDS type="Node" left="20400" top="1845" width="100" height="100">
    </BOUNDS>
@@ -991,14 +913,6 @@
    </LINKPOINT>
    <LINKPOINT x="6510" y="4013">
    </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="267" srcpinname="Y Output Value" dstnodeid="213" dstpinname="Enabled" linkstyle="VHV">
-   <LINKPOINT x="21780" y="12405">
-   </LINKPOINT>
-   <LINKPOINT x="2355" y="12420">
-   </LINKPOINT>
-   </LINK>
-   <LINK srcnodeid="213" srcpinname="Layer" dstnodeid="260" dstpinname="Layer 2">
    </LINK>
    <NODE systemname="xyZ (3d XY)" nodename="xyZ (3d XY)" componentmode="Hidden" id="270">
    <BOUNDS type="Node" left="10725" top="4260" width="100" height="100">
@@ -1080,4 +994,84 @@
    </LINK>
    <PACK Name="CV" Version="0.2.0">
    </PACK>
+   <NODE systemname="Cursor (DX9 OwnLegacy FixedEnum)" filename="Cursor (DX9 OwnLegacy FixedEnum).v4p" nodename="Cursor (DX9 OwnLegacy FixedEnum)" componentmode="Hidden" id="275">
+   <BOUNDS type="Node" left="6030" top="10605" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Mouse" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Cursor Type" visible="1">
+   </PIN>
+   <PIN pinname="Selection" visible="1">
+   </PIN>
+   <PIN pinname="Enabled" visible="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="212" srcpinname="Output Node" dstnodeid="275" dstpinname="Mouse" linkstyle="VHV">
+   <LINKPOINT x="16845" y="10230">
+   </LINKPOINT>
+   <LINKPOINT x="6060" y="10230">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="158" srcpinname="Output Enum" dstnodeid="275" dstpinname="Cursor Type" linkstyle="VHV">
+   <LINKPOINT x="13860" y="10305">
+   </LINKPOINT>
+   <LINKPOINT x="6225" y="10305">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="252" srcpinname="Y Output Value" dstnodeid="275" dstpinname="Selection" linkstyle="VHV">
+   <LINKPOINT x="15480" y="10410">
+   </LINKPOINT>
+   <LINKPOINT x="6735" y="10410">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="144" srcpinname="Y Output Value" dstnodeid="275" dstpinname="Enabled" linkstyle="VHV">
+   <LINKPOINT x="19380" y="10530">
+   </LINKPOINT>
+   <LINKPOINT x="6900" y="10530">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="275" srcpinname="Layer" dstnodeid="238" dstpinname="Layer 3">
+   </LINK>
+   <NODE systemname="Cursor (DX9 OwnLegacy FixedEnum)" filename="Cursor (DX9 OwnLegacy FixedEnum).v4p" nodename="Cursor (DX9 OwnLegacy FixedEnum)" componentmode="Hidden" id="276">
+   <BOUNDS type="Node" left="1620" top="12600" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Mouse" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Cursor Type" visible="1" slicecount="1" values="Cross">
+   </PIN>
+   <PIN pinname="Selection" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Enabled" visible="1" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="212" srcpinname="Output Node" dstnodeid="276" dstpinname="Mouse" linkstyle="VHV">
+   <LINKPOINT x="16845" y="12225">
+   </LINKPOINT>
+   <LINKPOINT x="1650" y="12225">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="158" srcpinname="Output Enum" dstnodeid="276" dstpinname="Cursor Type" linkstyle="VHV">
+   <LINKPOINT x="13860" y="12360">
+   </LINKPOINT>
+   <LINKPOINT x="1815" y="12360">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="252" srcpinname="Y Output Value" dstnodeid="276" dstpinname="Selection" linkstyle="VHV">
+   <LINKPOINT x="15480" y="12465">
+   </LINKPOINT>
+   <LINKPOINT x="2325" y="12465">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="267" srcpinname="Y Output Value" dstnodeid="276" dstpinname="Enabled" linkstyle="VHV">
+   <LINKPOINT x="21630" y="12540">
+   </LINKPOINT>
+   <LINKPOINT x="2490" y="12540">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="276" srcpinname="Layer" dstnodeid="260" dstpinname="Layer 2">
+   </LINK>
    </PATCH>

--- a/sub/Source (DX9).v4p
+++ b/sub/Source (DX9).v4p
@@ -1,6 +1,6 @@
 <!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.7.dtd" >
    <PATCH nodename="D:\GIT\badMapper\sub\Source (DX9).v4p" systemname="source" filename="C:\Users\Domi\Documents\GitHub\badMapper-v3.0\sub\source.v4p" scrollx="0" scrolly="-360">
-   <BOUNDS type="Window" left="6615" top="2070" width="24645" height="13155">
+   <BOUNDS type="Window" left="2475" top="630" width="24645" height="13155">
    </BOUNDS>
    <PACK Name="addonpack" Version="35.0.0">
    </PACK>
@@ -242,28 +242,6 @@
    </LINK>
    <LINK srcnodeid="76" srcpinname="Transform Out" dstnodeid="31" dstpinname="Transform">
    </LINK>
-   <NODE systemname="Cursor (DX9 Legacy 2)" filename="D:\gitHub\vvvv-sdk\vvvv45\lib\nodes\modules\EX9\Cursor (DX9).v4p" nodename="Cursor (DX9)" componentmode="Hidden" id="64">
-   <BOUNDS type="Node" left="5220" top="10905" width="960" height="270">
-   </BOUNDS>
-   <PIN pinname="Mouse" visible="1" slicecount="1" values="||">
-   </PIN>
-   <PIN pinname="Layer" visible="1">
-   </PIN>
-   <PIN pinname="Enabled" visible="1">
-   </PIN>
-   <PIN pinname="Cursor Type" visible="1" slicecount="1" values="Cross">
-   </PIN>
-   <PIN pinname="Color" slicecount="1" values="|1.00000,1.00000,1.00000,1.00000|">
-   </PIN>
-   <PIN pinname="Selection" slicecount="1" visible="1" values="0">
-   </PIN>
-   </NODE>
-   <LINK srcnodeid="65" srcpinname="Output Enum" dstnodeid="64" dstpinname="Cursor Type" linkstyle="VHV">
-   <LINKPOINT x="14200" y="10655">
-   </LINKPOINT>
-   <LINKPOINT x="5765" y="10675">
-   </LINKPOINT>
-   </LINK>
    <PACK Name="imagepack" Version="0.1.0">
    </PACK>
    <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="92" systemname="IOBox (Value Advanced)">
@@ -282,10 +260,6 @@
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="64" srcpinname="Layer" dstnodeid="22" dstpinname="Layer 4">
-   </LINK>
-   <LINK srcnodeid="64" srcpinname="Layer" dstnodeid="22" dstpinname="Layer 3">
-   </LINK>
    <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="98">
    <BOUNDS type="Node" left="17250" top="975" width="100" height="100">
    </BOUNDS>
@@ -296,12 +270,6 @@
    <PIN pinname="Output Node" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="98" srcpinname="Output Node" dstnodeid="64" dstpinname="Mouse" linkstyle="VHV">
-   <LINKPOINT x="18170" y="10570">
-   </LINKPOINT>
-   <LINKPOINT x="4360" y="10610">
-   </LINKPOINT>
-   </LINK>
    <LINK srcnodeid="56" srcpinname="Layer" dstnodeid="41" dstpinname="Layer 1">
    </LINK>
    <NODE systemname="DisplayInfo (DX9)" filename="DisplayInfo (DX9).v4p" componentmode="Hidden" id="115" nodename="DisplayInfo (DX9).v4p" stayontop="0">
@@ -402,12 +370,6 @@
    <PIN pinname="Y Output Value" visible="1">
    </PIN>
    </NODE>
-   <LINK srcnodeid="125" srcpinname="Y Output Value" dstnodeid="64" dstpinname="Selection" linkstyle="VHV">
-   <LINKPOINT x="15810" y="10800">
-   </LINKPOINT>
-   <LINKPOINT x="5955" y="10800">
-   </LINKPOINT>
-   </LINK>
    <NODE id="100" systemname="Filter (EX9.SamplerState)" nodename="Filter (EX9.SamplerState)" componentmode="Hidden">
    <BOUNDS type="Node" left="1635" top="9345" width="750" height="270">
    </BOUNDS>
@@ -604,12 +566,6 @@
    </LINK>
    <LINK srcnodeid="157" srcpinname="Y Output Value" dstnodeid="158" dstpinname="Input 2">
    </LINK>
-   <LINK srcnodeid="156" srcpinname="Y Output Value" dstnodeid="64" dstpinname="Enabled" linkstyle="VHV">
-   <LINKPOINT x="18225" y="10825">
-   </LINKPOINT>
-   <LINKPOINT x="6480" y="10865">
-   </LINKPOINT>
-   </LINK>
    <LINK srcnodeid="9" srcpinname="Output Node" dstnodeid="23" dstpinname="Texture">
    </LINK>
    <LINK srcnodeid="158" srcpinname="Output" dstnodeid="31" dstpinname="Enabled" linkstyle="VHV">
@@ -638,4 +594,46 @@
    </LINK>
    <INFO author="dominikKoller" description="EX9 Layer for the Source Renderer" tags="">
    </INFO>
+   <NODE systemname="Cursor (DX9 OwnLegacy FixedEnum)" filename="Cursor (DX9 OwnLegacy FixedEnum).v4p" nodename="Cursor (DX9 OwnLegacy FixedEnum)" componentmode="Hidden" id="161">
+   <BOUNDS type="Node" left="5190" top="10860" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Window" left="5310" top="840" width="19065" height="13830">
+   </BOUNDS>
+   <PIN pinname="Mouse" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Cursor Type" visible="1">
+   </PIN>
+   <PIN pinname="Selection" visible="1">
+   </PIN>
+   <PIN pinname="Enabled" visible="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="98" srcpinname="Output Node" dstnodeid="161" dstpinname="Mouse" linkstyle="VHV">
+   <LINKPOINT x="17280" y="10455">
+   </LINKPOINT>
+   <LINKPOINT x="5220" y="10455">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="65" srcpinname="Output Enum" dstnodeid="161" dstpinname="Cursor Type" linkstyle="VHV">
+   <LINKPOINT x="14535" y="10575">
+   </LINKPOINT>
+   <LINKPOINT x="5385" y="10575">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="125" srcpinname="Y Output Value" dstnodeid="161" dstpinname="Selection" linkstyle="VHV">
+   <LINKPOINT x="15795" y="10650">
+   </LINKPOINT>
+   <LINKPOINT x="5895" y="10650">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="156" srcpinname="Y Output Value" dstnodeid="161" dstpinname="Enabled" linkstyle="VHV">
+   <LINKPOINT x="18555" y="10785">
+   </LINKPOINT>
+   <LINKPOINT x="6060" y="10785">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="161" srcpinname="Layer" dstnodeid="22" dstpinname="Layer 3">
+   </LINK>
    </PATCH>

--- a/sub/Source (DX9).v4p
+++ b/sub/Source (DX9).v4p
@@ -1,8 +1,8 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45alpha32.2.dtd" >
-   <PATCH nodename="C:\Users\Domi\Documents\GitHub\badMapper\sub\Source (DX9).v4p" systemname="source" filename="C:\Users\Domi\Documents\GitHub\badMapper-v3.0\sub\source.v4p" scrollx="0" scrolly="-360">
-   <BOUNDS type="Window" left="2475" top="630" width="24645" height="13155">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.7.dtd" >
+   <PATCH nodename="D:\GIT\badMapper\sub\Source (DX9).v4p" systemname="source" filename="C:\Users\Domi\Documents\GitHub\badMapper-v3.0\sub\source.v4p" scrollx="0" scrolly="-360">
+   <BOUNDS type="Window" left="6615" top="2070" width="24645" height="13155">
    </BOUNDS>
-   <PACK Name="addonpack" Version="32.2.0">
+   <PACK Name="addonpack" Version="35.0.0">
    </PACK>
    <NODE systemname="Group (EX9)" nodename="Group (EX9)" componentmode="Hidden" id="41">
    <BOUNDS type="Node" left="4140" top="9990" width="8040" height="270">
@@ -17,7 +17,7 @@
    </PIN>
    <PIN pinname="Layer 3" visible="1" slicecount="1" values="||">
    </PIN>
-   <PIN pinname="Enabled" slicecount="1" visible="-1" values="1" pintype="Input">
+   <PIN pinname="Enabled" slicecount="1" visible="-1" pintype="Input" values="1">
    </PIN>
    <PIN pinname="Layer 5" visible="1" slicecount="1" values="||">
    </PIN>
@@ -41,7 +41,7 @@
    </PIN>
    <PIN pinname="Show Brush" slicecount="1" values="1">
    </PIN>
-   <PIN pinname="Font" slicecount="1" values="|HelveticaNeueLT Std|">
+   <PIN pinname="Font" slicecount="1" values="Arial">
    </PIN>
    <PIN pinname="Vertical Align" slicecount="1" values="Bottom">
    </PIN>
@@ -242,7 +242,7 @@
    </LINK>
    <LINK srcnodeid="76" srcpinname="Transform Out" dstnodeid="31" dstpinname="Transform">
    </LINK>
-   <NODE systemname="Cursor (DX9)" filename="D:\gitHub\vvvv-sdk\vvvv45\lib\nodes\modules\EX9\Cursor (DX9).v4p" nodename="Cursor (DX9)" componentmode="Hidden" id="64">
+   <NODE systemname="Cursor (DX9 Legacy 2)" filename="D:\gitHub\vvvv-sdk\vvvv45\lib\nodes\modules\EX9\Cursor (DX9).v4p" nodename="Cursor (DX9)" componentmode="Hidden" id="64">
    <BOUNDS type="Node" left="5220" top="10905" width="960" height="270">
    </BOUNDS>
    <PIN pinname="Mouse" visible="1" slicecount="1" values="||">

--- a/sub/badMapperModel.v4p
+++ b/sub/badMapperModel.v4p
@@ -1,5 +1,5 @@
-<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv45beta34.2.dtd" >
-   <PATCH nodename="C:\Users\joreg\Documents\repos\badMapper\sub\badMapperModel.v4p" scrollx="30" scrolly="0" systemname="badMapperModel" filename="C:\Users\Domi\Documents\GitHub\badMapper\sub\badMapperModel.v4p" locked="0" bgcolor="14737632">
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50beta35.7.dtd" >
+   <PATCH nodename="D:\GIT\badMapper\sub\badMapperModel.v4p" scrollx="30" scrolly="0" systemname="badMapperModel" filename="C:\Users\Domi\Documents\GitHub\badMapper\sub\badMapperModel.v4p" locked="0" bgcolor="14737632">
    <NODE systemname="Windowing" filename="Windowing.v4p" componentmode="Hidden" id="0" nodename="Windowing.v4p" hiddenwhenlocked="0">
    <BOUNDS type="Node" left="7995" top="2775" width="1515" height="270">
    </BOUNDS>
@@ -392,11 +392,11 @@
    </NODE>
    <LINK srcnodeid="43" srcpinname="Output Node" dstnodeid="17" dstpinname="Keyboard" hiddenwhenlocked="1">
    </LINK>
-   <BOUNDS type="Window" left="11010" top="2070" width="19500" height="15300">
+   <BOUNDS type="Window" left="3645" top="0" width="19500" height="15300">
    </BOUNDS>
    <PACK Name="VVVV.Packs" Version="0.1.0">
    </PACK>
-   <PACK Name="addonpack" Version="34.1.0">
+   <PACK Name="addonpack" Version="35.0.0">
    </PACK>
    <NODE systemname="Divide (Value)" nodename="Divide (Value)" componentmode="Hidden" id="45">
    <BOUNDS type="Node" left="2565" top="1830" width="720" height="270">
@@ -546,7 +546,7 @@
    <PIN pinname="String Type" slicecount="1" values="MultiLine">
    </PIN>
    </NODE>
-   <NODE systemname="Camera (Transform 2d)" filename="%VVVV%\lib\nodes\modules\Transform\Camera (Transform 2d).v4p" nodename="Camera (Transform 2d)" componentmode="Hidden" id="66">
+   <NODE systemname="Camera (Transform 2d Legacy)" filename="%VVVV%\lib\nodes\modules\Transform\Camera (Transform 2d).v4p" nodename="Camera (Transform 2d)" componentmode="Hidden" id="66">
    <BOUNDS type="Node" left="525" top="4800" width="100" height="100">
    </BOUNDS>
    <BOUNDS type="Box" left="525" top="4800">
@@ -558,7 +558,7 @@
    </LINK>
    <LINK srcnodeid="66" srcpinname="Transform Out" dstnodeid="60" dstpinname="Input Node">
    </LINK>
-   <NODE systemname="Camera (Transform 2d)" filename="%VVVV%\lib\nodes\modules\Transform\Camera (Transform 2d).v4p" nodename="Camera (Transform 2d)" componentmode="Hidden" id="67">
+   <NODE systemname="Camera (Transform 2d Legacy)" filename="%VVVV%\lib\nodes\modules\Transform\Camera (Transform 2d).v4p" nodename="Camera (Transform 2d)" componentmode="Hidden" id="67">
    <BOUNDS type="Node" left="1620" top="4800" width="100" height="100">
    </BOUNDS>
    <BOUNDS type="Box" left="1620" top="4800">
@@ -680,4 +680,18 @@
    </LINK>
    <LINK srcnodeid="70" srcpinname="Bang" dstnodeid="68" dstpinname="Remove">
    </LINK>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="72">
+   <BOUNDS type="Node" left="495" top="4065" width="5040" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="495" top="4065" width="2835" height="540">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Still using legacy camera, the new one has different Window handling.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
    </PATCH>


### PR DESCRIPTION
Legacy cursor nodes were red as the were getting the new cursorMode enum from the PolygonEditor.
Text node was red if Helvetica was not installed.

Still using the legacy cursor nodes, the new ones don't have the mouse input we need. Made own legacy node and put it inside this repo.
Using Arial instead of Helvetica.